### PR TITLE
fix auto.create.topics config write

### DIFF
--- a/scripts/start-kafka.sh
+++ b/scripts/start-kafka.sh
@@ -64,7 +64,7 @@ fi
 # Enable/disable auto creation of topics
 if [ ! -z "$AUTO_CREATE_TOPICS" ]; then
     echo "auto.create.topics.enable: $AUTO_CREATE_TOPICS"
-    echo "auto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
+    echo "\nauto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
 fi
 
 # Run Kafka


### PR DESCRIPTION
Because it wasn't using a new line, writing the auto.create.topics config was appended to the last configuration line:

`group.initial.rebalance.delay.ms=0auto.create.topics.enable=true`