### PR TITLE
Updated zookeper version to 3.4.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get clean
 
 
-ENV ZOOKEEPER_VERSION 3.4.11
+ENV ZOOKEEPER_VERSION 3.4.12
 ENV ZOOKEEPER_HOME /opt/zookeeper-"$ZOOKEEPER_VERSION"
 
 RUN wget -q http://ftp.cixug.es/apache/zookeeper/zookeeper-"$ZOOKEEPER_VERSION"/zookeeper-"$ZOOKEEPER_VERSION".tar.gz -O /tmp/zookeeper-"$ZOOKEEPER_VERSION".tgz


### PR DESCRIPTION
Previous version 3.4.11 has been removed from http://ftp.cixug.es/apache/zookeeper mirror and was causing an error on docker build