### PR TITLE
Add gcompat to base image to fix missing ld-linux-x86-64.so.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Kafka and Zookeeper
 FROM alpine:3.9.2
 
-RUN apk add --update openjdk8-jre supervisor bash
+RUN apk add --update openjdk8-jre supervisor bash gcompat
 
 ENV ZOOKEEPER_VERSION 3.4.13
 ENV ZOOKEEPER_HOME /opt/zookeeper-"$ZOOKEEPER_VERSION"


### PR DESCRIPTION
Testing with a simple producer/consumer client presently triggers:

UnsatisfiedLinkError: /tmp/snappy-1.1.4-libsnappyjava.so Error loading shared library ld-linux-x86-64.so.2: No such file or directory
...

Under alpine, ld-linux-x86-64.so.2 can be brought in either by
libc6-compat or the more minimal gcompat. In this case, gcompat is
used in the interest of keeping the container size to a minimum.