### PR TITLE
Remove broken newline

### DIFF
--- a/assets/scripts/start-kafka.sh
+++ b/assets/scripts/start-kafka.sh
@@ -73,7 +73,7 @@ fi
 # Enable/disable auto creation of topics
 if [ ! -z "$AUTO_CREATE_TOPICS" ]; then
     echo "auto.create.topics.enable: $AUTO_CREATE_TOPICS"
-    echo "\nauto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
+    echo "auto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
 fi
 
 # Run Kafka


### PR DESCRIPTION
When setting `AUTO_CREATE_TOPICS=false` and inspecting the `server.properties` in the Docker container I noticed the `"\n"` gets printed in the file as is. `>>` will automatically add a newline for us so I removed the prefix.

You can try by running:
```
$ echo "foo" > test.txt
$ echo "bar" >> test.txt
$ cat test.txt
foo
bar
```