### PR TITLE
Support arm64 builds using 'docker buildx'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Kafka and Zookeeper
-FROM alpine:3.9.2
+FROM alpine:3.15
 
 RUN apk add --update openjdk8-jre supervisor bash gcompat
 
@@ -12,7 +12,7 @@ RUN tar xfz /tmp/zookeeper-"$ZOOKEEPER_VERSION".tgz -C /opt && rm /tmp/zookeeper
 ADD assets/conf/zoo.cfg $ZOOKEEPER_HOME/conf
 
 ENV SCALA_VERSION 2.13
-ENV KAFKA_VERSION 2.6.0
+ARG KAFKA_VERSION=2.6.0
 ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
 ENV KAFKA_DOWNLOAD_URL https://archive.apache.org/dist/kafka/"$KAFKA_VERSION"/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
 

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,16 @@ BUILDER ?= builder-local
 KAFKA_VERSION ?= 2.6.0
 
 # TAG
-TAG = dougdonohoe/kafka-zookeeper:$(KAFKA_VERSION)
+TAG = $(REPO_NAME)/kafka-zookeeper:$(KAFKA_VERSION)
+
+require_repo_name:
+ifndef REPO_NAME
+	$(error REPO_NAME not set)
+endif
 
 # common setup for buildx tasks
 buildx-setup:
+	@echo "Current buildx builders:"
 	$(DOCKER) buildx ls
 	@if ! $(DOCKER) buildx inspect --builder $(BUILDER) > /dev/null 2>&1; then \
   		echo "Creating new builder '$(BUILDER)'"; \
@@ -34,7 +40,7 @@ buildx-setup:
 	fi
 
 ## buildx-publish: build and publish the multi-architecture image (amd64|arm64)
-buildx-publish:
+buildx-publish: require_repo_name buildx-setup
 	@echo '=> Build and publish multi-arch image $(TAG)...'
 	$(DOCKER) buildx build --file Dockerfile \
 		--platform $(PLATFORMS) \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# Makefile for creating kafka-zookeeper Docker image
+#
+
+# 1st item is default, so 'make' with no arguments shows help
+## help: show this help message
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' | sed -e 's/^/ /' | sort
+
+
+# define docker to run using BUILDKIT features
+DOCKER = DOCKER_BUILDKIT=1 docker
+
+# Platforms defaults to amd64 and arm64, but one can override at runtime (e.g., PLATFORMS=linux/amd64 make xxx)
+PLATFORMS ?= linux/amd64,linux/arm64
+
+# Set buildx builder
+BUILDER ?= builder-local
+
+# Kafka Version
+KAFKA_VERSION ?= 2.6.0
+
+# TAG
+TAG = dougdonohoe/kafka-zookeeper:$(KAFKA_VERSION)
+
+# common setup for buildx tasks
+buildx-setup:
+	$(DOCKER) buildx ls
+	@if ! $(DOCKER) buildx inspect --builder $(BUILDER) > /dev/null 2>&1; then \
+  		echo "Creating new builder '$(BUILDER)'"; \
+  		$(DOCKER) buildx create --name $(BUILDER); \
+	else \
+		echo "Using existing builder $(BUILDER)"; \
+	fi
+
+## buildx-publish: build and publish the multi-architecture image (amd64|arm64)
+buildx-publish:
+	@echo '=> Build and publish multi-arch image $(TAG)...'
+	$(DOCKER) buildx build --file Dockerfile \
+		--platform $(PLATFORMS) \
+		--builder $(BUILDER) \
+		--build-arg KAFKA_VERSION=$(KAFKA_VERSION) \
+		--progress plain \
+		--pull --push --tag $(TAG) .

--- a/README.md
+++ b/README.md
@@ -45,3 +45,21 @@ https://hub.docker.com/r/johnnypark/kafka-zookeeper/
 Credits
 -------
 Originally cloned and inspired by https://github.com/spotify/docker-kafka
+
+Multi Architecture Support
+--------------------------
+
+To create an image supporting multiple architectures, one needs to use `docker buildx` command,
+as defined in the Makefile.
+
+To build default Kafka version:
+
+```shell
+make buildx-publish
+```
+
+To build a different version:
+
+```shell
+KAFKA_VERSION=2.6.2 make buildx-publish
+```

--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ Multi Architecture Support
 To create an image supporting multiple architectures, one needs to use `docker buildx` command,
 as defined in the Makefile.
 
+You need to define `REPO_NAME` to specify where the image will be pushed.
+
 To build default Kafka version:
 
 ```shell
-make buildx-publish
+REPO_NAME=my-repo make buildx-publish
 ```
 
 To build a different version:
 
 ```shell
-KAFKA_VERSION=2.6.2 make buildx-publish
+KAFKA_VERSION=2.6.2 REPO_NAME=my-repo make buildx-publish
 ```


### PR DESCRIPTION
Now that Apple M1 (Apple Silicon) Macs are becoming more common, it is desirable to have tools like this support both `amd64` and `arm64` images.  This PR adds a `Makefile` with the commands necessary to build and publish such an image as well as instructions in the `README`.

I also bumped Alpine to v3.15 and made it easier to publish a different version of Kafka.

The owner of this repo should be able to publish a multi-arch image:

```
REPO_NAME=johnnypark make buildx-publish 
```

I also published my image to https://hub.docker.com/r/dougdonohoe/kafka-zookeeper.